### PR TITLE
[fix]: fixed redundant merging

### DIFF
--- a/mailmerge.py
+++ b/mailmerge.py
@@ -243,7 +243,7 @@ class MailMerge(object):
                                         nbreak.attrib['{%(w)s}type' % NAMESPACES] = type
                                         r.append(nbreak)
 
-                    self.merge(parts, **repl)
+                self.merge(parts, **repl)
 
     def merge_pages(self, replacements):
          """


### PR DESCRIPTION
## Description
Changed a single tab in order to make it so `merge` function in `merge_templates` isn't called more often than needed.

## Motivation and Context
It makes things faster and take up less resources.

## How Has This Been Tested?
Ran local tests to confirm files were identical while saving time.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
